### PR TITLE
Iter14: feat(hashing): add agent/server hash calculating when updating metrics

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -32,6 +32,13 @@ func main() {
 		PollInterval:   time.Duration(*options.PollInterval) * time.Second,
 		ReportInterval: time.Duration(*options.ReportInterval) * time.Second,
 		MaxRetries:     &maxRetrySendCount,
+		Hashing: struct {
+			Key        *string
+			HeaderName string
+		}{
+			Key:        options.Key,
+			HeaderName: "hashsha256",
+		},
 	})
 	agent.Launch()
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -31,7 +31,7 @@ func main() {
 		},
 		PollInterval:   time.Duration(*options.PollInterval) * time.Second,
 		ReportInterval: time.Duration(*options.ReportInterval) * time.Second,
-		MaxRetries:     &maxRetrySendCount,
+		MaxRetries:     maxRetrySendCount,
 		Hashing: struct {
 			Key        *string
 			HeaderName string

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -136,9 +136,9 @@ func hashBodyByKey(key *string, body []byte) string {
 }
 
 func (m *agent) performRequest(url string) (err error) {
-	defer m.mu.Unlock()
 	m.config.Logger.Info("Sending metrics to server...")
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	body := prepareRequestBody(m.metrics)
 	m.config.Logger.Info("Sending metrics", zap.ByteString("body", body))
 	r, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -198,7 +198,7 @@ func (s *performRequestTestSuite) SetupTest() {
 			},
 			PollInterval:   50 * time.Millisecond,
 			ReportInterval: 100 * time.Millisecond,
-			MaxRetries:     &retries,
+			MaxRetries:     retries,
 		},
 		metrics: map[string]models.Metrics{},
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -66,10 +66,11 @@ func TestNewAgent(t *testing.T) {
 }
 
 func Test_agent_sendMetrics(t *testing.T) {
-	var isServerWasCalled = false
+	var isServerWasCalled atomic.Value
+	isServerWasCalled.Store(false)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		isServerWasCalled = true
+		isServerWasCalled.Store(true)
 	}))
 	testServerURL, _ := url.Parse(ts.URL)
 	defer ts.Close()
@@ -129,7 +130,7 @@ func Test_agent_sendMetrics(t *testing.T) {
 			}
 			go m.sendMetrics(tt.args.stop)
 			time.Sleep(150 * time.Millisecond)
-			require.Equal(t, tt.want, isServerWasCalled)
+			require.Equal(t, tt.want, isServerWasCalled.Load().(bool))
 		})
 	}
 }
@@ -139,7 +140,6 @@ func Test_agent_collectMetrics(t *testing.T) {
 		URL     string
 		config  *Config
 		metrics map[string]models.Metrics
-		mu      sync.Mutex
 	}
 	type args struct {
 		stop chan struct{}
@@ -159,7 +159,6 @@ func Test_agent_collectMetrics(t *testing.T) {
 					PollInterval:   50 * time.Millisecond,
 					ReportInterval: 100 * time.Second,
 				},
-				mu: sync.Mutex{},
 			},
 		},
 	}
@@ -169,11 +168,12 @@ func Test_agent_collectMetrics(t *testing.T) {
 			m := &agent{
 				config:  tt.fields.config,
 				metrics: tt.fields.metrics,
-				mu:      sync.Mutex{},
 			}
 			go m.collectMetrics(tt.args.stop)
 			time.Sleep(100 * time.Millisecond)
+			m.mu.Lock()
 			result := len(m.metrics)
+			m.mu.Unlock()
 			require.NotEqual(t, result, 0, "Expected metrics to be collected")
 		})
 	}

--- a/internal/config/env/vars.go
+++ b/internal/config/env/vars.go
@@ -15,6 +15,7 @@ type Variables struct {
 	FileStoragePath *string `env:"FILE_STORAGE_PATH"`
 	Restore         *bool   `env:"RESTORE"`
 	DatabaseDSN     *string `env:"DATABASE_DSN"`
+	Key             *string `env:"KEY"`
 }
 
 func ParseAgentOptions() *Variables {
@@ -22,12 +23,14 @@ func ParseAgentOptions() *Variables {
 	var endpointFlag = &Endpoint{Hostname: "localhost", Port: 8080}
 	var reportInterval = new(uint)
 	var pollInterval = new(uint)
+	var key = new(string)
 	if err := env.Parse(&envVars); err != nil {
 		log.Fatal(err)
 	}
 	flag.Var(endpointFlag, "a", "set endpoint (host:port)")
 	flag.UintVar(reportInterval, "r", 10, "set report interval (seconds)")
 	flag.UintVar(pollInterval, "p", 2, "set poll interval (seconds)")
+	flag.StringVar(key, "k", "", "set key used for hashing")
 	flag.Parse()
 	return &Variables{
 		Endpoint: func() *string {
@@ -49,6 +52,12 @@ func ParseAgentOptions() *Variables {
 			}
 			return pollInterval
 		}(),
+		Key: func() *string {
+			if envVars.Key != nil {
+				return envVars.Key
+			}
+			return key
+		}(),
 	}
 }
 
@@ -59,6 +68,7 @@ func ParseServerOptions() *Variables {
 	var fileStoragePath = new(string)
 	var restore = new(bool)
 	var dsn = new(string)
+	var key = new(string)
 	if err := env.Parse(&envVars); err != nil {
 		log.Fatal(err)
 	}
@@ -67,6 +77,7 @@ func ParseServerOptions() *Variables {
 	flag.BoolVar(restore, "r", false, "set restore")
 	flag.Var(endpointFlag, "a", "set endpoint (host:port)")
 	flag.StringVar(dsn, "d", "", "set database dsn")
+	flag.StringVar(key, "k", "", "set key used for hashing")
 	flag.Parse()
 	return &Variables{
 		Endpoint: func() *string {
@@ -99,6 +110,12 @@ func ParseServerOptions() *Variables {
 				return envVars.DatabaseDSN
 			}
 			return dsn
+		}(),
+		Key: func() *string {
+			if envVars.Key != nil {
+				return envVars.Key
+			}
+			return key
 		}(),
 	}
 }

--- a/internal/handler/get_metric.go
+++ b/internal/handler/get_metric.go
@@ -1,21 +1,29 @@
 package handler
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"strings"
 
+	"github.com/funkymotions/go-ya-practicum-metrics/internal/service"
 	"github.com/go-chi/chi"
 )
 
 func (h *metricHandler) GetMetric(w http.ResponseWriter, r *http.Request) {
 	metricName := strings.TrimSpace(chi.URLParam(r, "name"))
 	metricType := strings.TrimSpace(chi.URLParam(r, "type"))
-	metric, found := h.service.GetMetric(metricName, metricType)
+	metric, err := h.service.GetMetric(metricName, metricType)
 	w.Header().Set("Content-Type", "text/plain")
-	if !found {
-		log.Printf("Metric %s not found\n", metricName)
-		w.WriteHeader(http.StatusNotFound)
+	var metricErr *service.InvalidMetricError
+	if errors.As(err, &metricErr) {
+		log.Printf("error while searching metric: %s, %s\n", metricName, metricErr)
+		w.WriteHeader(metricErr.StatusCode)
+		return
+	}
+	if err != nil {
+		log.Printf("error while searching metric: %s, %v\n", metricName, err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	w.Write([]byte(metric.String()))

--- a/internal/handler/get_metric_json.go
+++ b/internal/handler/get_metric_json.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	models "github.com/funkymotions/go-ya-practicum-metrics/internal/model"
+	"github.com/funkymotions/go-ya-practicum-metrics/internal/service"
 )
 
 func (h *metricHandler) GetMetricByJSON(w http.ResponseWriter, r *http.Request) {
@@ -14,14 +16,20 @@ func (h *metricHandler) GetMetricByJSON(w http.ResponseWriter, r *http.Request) 
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	// TODO: move deserialization to service layer
 	var metric models.Metrics
 	if err := json.NewDecoder(r.Body).Decode(&metric); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	m, err := h.service.GetMetricByModel(&metric)
+	var metricErr *service.InvalidMetricError
+	if errors.As(err, &metricErr) {
+		w.WriteHeader(metricErr.StatusCode)
+		return
+	}
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	if err := json.NewEncoder(w).Encode(m); err != nil {

--- a/internal/handler/metric.go
+++ b/internal/handler/metric.go
@@ -11,11 +11,11 @@ import (
 type metricService interface {
 	SetCounter(name string, value string) error
 	SetGauge(name string, value string) error
-	SetMetricByModel(m *models.Metrics) error
+	SetMetricByModel([]byte) (*models.Metrics, error)
 	GetMetricByModel(m *models.Metrics) (*models.Metrics, error)
-	GetMetric(metricType, name string) (*models.Metrics, bool)
+	GetMetric(metricType, name string) (*models.Metrics, error)
 	GetAllMetricsForHTML() string
-	SetMetricBulk(m *[]models.Metrics) error
+	SetMetricBulk([]byte, []byte) error
 	Ping() error
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	appenv "github.com/funkymotions/go-ya-practicum-metrics/internal/config/env"
 	"github.com/funkymotions/go-ya-practicum-metrics/internal/driver"
 	"github.com/funkymotions/go-ya-practicum-metrics/internal/handler"
+	"github.com/funkymotions/go-ya-practicum-metrics/internal/logger"
 	"github.com/funkymotions/go-ya-practicum-metrics/internal/middleware"
 	"github.com/funkymotions/go-ya-practicum-metrics/internal/repository"
 	"github.com/funkymotions/go-ya-practicum-metrics/internal/service"
@@ -47,11 +48,10 @@ func NewServer(v *appenv.Variables) *Server {
 	dbConf := db.NewDBConfig(*v.DatabaseDSN)
 	d, _ := driver.NewSQLDriver(dbConf)
 	// logger
-	// logger, err := logger.NewLogger(zap.NewAtomicLevelAt(zap.InfoLevel))
-	logger := zap.NewNop()
-	// if err != nil {
-	// 	log.Fatalf("failed to initialize logger: %v", err)
-	// }
+	logger, err := logger.NewLogger(zap.NewAtomicLevelAt(zap.InfoLevel))
+	if err != nil {
+		log.Fatalf("failed to initialize logger: %v", err)
+	}
 	// channels
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
@@ -65,7 +65,7 @@ func NewServer(v *appenv.Variables) *Server {
 		doneCh,
 	)
 	// services
-	metricService := service.NewMetricService(metricRepo)
+	metricService := service.NewMetricService(metricRepo, []byte(*v.Key))
 	// handlers
 	metricHandler := handler.NewMetricHandler(metricService)
 	// routing

--- a/internal/service/metric.go
+++ b/internal/service/metric.go
@@ -1,15 +1,28 @@
 package service
 
 import (
-	"errors"
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
-	"time"
 
 	models "github.com/funkymotions/go-ya-practicum-metrics/internal/model"
-	"github.com/funkymotions/go-ya-practicum-metrics/internal/repository"
+	"github.com/funkymotions/go-ya-practicum-metrics/internal/utils"
 )
+
+type InvalidMetricError struct {
+	Message    string
+	StatusCode int
+}
+
+func (e *InvalidMetricError) Error() string {
+	return fmt.Sprintf("code %d: %s", e.StatusCode, e.Message)
+}
 
 type metricRepoInterface interface {
 	SetGauge(name string, parameter float64)
@@ -23,24 +36,32 @@ type metricRepoInterface interface {
 }
 
 type metricService struct {
-	repo metricRepoInterface
-	re   *regexp.Regexp
+	repo       metricRepoInterface
+	re         *regexp.Regexp
+	hashSecret []byte
 }
 
-func NewMetricService(repo metricRepoInterface) *metricService {
+func NewMetricService(repo metricRepoInterface, hashSecret []byte) *metricService {
 	return &metricService{
-		repo: repo,
-		re:   regexp.MustCompile(`^\w+$`),
+		repo:       repo,
+		re:         regexp.MustCompile(`^\w+$`),
+		hashSecret: hashSecret,
 	}
 }
 
 func (s *metricService) SetCounter(name string, rawValue string) error {
 	if !isMetricNameAlphanumeric(name, s.re) {
-		return fmt.Errorf("invalid metric name: %s", name)
+		return &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric name: %s", name),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 	value, err := strconv.ParseInt(rawValue, 10, 64)
 	if err != nil {
-		return err
+		return &InvalidMetricError{
+			Message:    err.Error(),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 	s.repo.SetCounterIntrospect(name, value)
 	return nil
@@ -48,22 +69,37 @@ func (s *metricService) SetCounter(name string, rawValue string) error {
 
 func (s *metricService) SetGauge(name string, rawValue string) error {
 	if !isMetricNameAlphanumeric(name, s.re) {
-		return fmt.Errorf("invalid metric name: %s", name)
+		return &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric name: %s", name),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 	value, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {
-		return err
+		return &InvalidMetricError{
+			Message:    err.Error(),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 	s.repo.SetGaugeIntrospect(name, value)
 	return nil
 }
 
-func (s *metricService) GetMetric(name string, metricType string) (*models.Metrics, bool) {
+func (s *metricService) GetMetric(name string, metricType string) (*models.Metrics, error) {
 	if !isMetricNameAlphanumeric(name, s.re) {
-		return nil, false
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric name: %s", name),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 	m, res := s.repo.GetMetric(name, metricType)
-	return m, res
+	if !res {
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("metric not found: %s", name),
+			StatusCode: http.StatusNotFound,
+		}
+	}
+	return m, nil
 }
 
 func (s *metricService) GetAllMetricsForHTML() string {
@@ -75,52 +111,65 @@ func (s *metricService) GetAllMetricsForHTML() string {
 	return result
 }
 
-func (s *metricService) SetMetricByModel(metric *models.Metrics) error {
-	if !isMetricNameAlphanumeric(metric.ID, s.re) {
-		return fmt.Errorf("invalid metric name: %s", metric.ID)
+func (s *metricService) SetMetricByModel(input []byte) (*models.Metrics, error) {
+	var metric models.Metrics
+	if err := json.NewDecoder(bytes.NewReader(input)).Decode(&metric); err != nil {
+		return nil, &InvalidMetricError{
+			Message:    err.Error(),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
+	if !isMetricNameAlphanumeric(metric.ID, s.re) {
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric name: %s", metric.ID),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	if !isMetricDataOK(&metric) {
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric data: %s", metric.ID),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	var retriableFn func() error
 	switch metric.MType {
 	case models.Gauge:
-		if metric.Value == nil {
-			return fmt.Errorf("invalid gauge metric: %s", metric.ID)
-		}
-		// err := s.repo.SetGaugeIntrospect(metric.ID, *metric.Value)
-		err := withRetry(func() error {
+		retriableFn = func() error {
 			return s.repo.SetGaugeIntrospect(metric.ID, *metric.Value)
-		}, 0, 3)
-		if err != nil {
-			var nonRetriable *repository.NonRetriablePgError
-			if errors.As(err, &nonRetriable) {
-				return nil
-			}
 		}
-		return err
 	case models.Counter:
-		if metric.Delta == nil {
-			return fmt.Errorf("invalid counter metric: %s", metric.ID)
-		}
-		err := withRetry(func() error {
+		retriableFn = func() error {
 			return s.repo.SetCounterIntrospect(metric.ID, *metric.Delta)
-		}, 0, 3)
-		if err != nil {
-			var nonRetriable *repository.NonRetriablePgError
-			if errors.As(err, &nonRetriable) {
-				return nil
-			}
 		}
-		return err
 	default:
-		return fmt.Errorf("invalid metric type: %s", metric.MType)
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric type: %s", metric.MType),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
+	// TODO: make maxAttempts configurable
+	if err := utils.WithRetry(retriableFn, 0, 3); err != nil {
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("failed to set metric: %s", err.Error()),
+			StatusCode: http.StatusInternalServerError,
+		}
+	}
+	return &metric, nil
 }
 
 func (s *metricService) GetMetricByModel(metric *models.Metrics) (*models.Metrics, error) {
 	if !isMetricNameAlphanumeric(metric.ID, s.re) {
-		return nil, fmt.Errorf("invalid metric name: %s", metric.ID)
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("invalid metric name: %s", metric.ID),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 	m, found := s.repo.GetMetric(metric.ID, metric.MType)
 	if !found {
-		return nil, fmt.Errorf("metric not found: %s", metric.ID)
+		return nil, &InvalidMetricError{
+			Message:    fmt.Sprintf("metric not found: %s", metric.ID),
+			StatusCode: http.StatusNotFound,
+		}
 	}
 	return m, nil
 }
@@ -129,29 +178,51 @@ func (s *metricService) Ping() error {
 	return s.repo.Ping()
 }
 
-func (s *metricService) SetMetricBulk(m *[]models.Metrics) error {
-	return s.repo.SetMetricBulk(m)
+func (s *metricService) SetMetricBulk(input []byte, signature []byte) error {
+	if len(s.hashSecret) > 0 {
+		if ok := isHashValid(signature, input, s.hashSecret); !ok {
+			return &InvalidMetricError{
+				Message:    "invalid hash",
+				StatusCode: http.StatusBadRequest,
+			}
+		}
+	}
+	var metrics []models.Metrics
+	if err := json.NewDecoder(bytes.NewReader(input)).Decode(&metrics); err != nil {
+		return &InvalidMetricError{
+			Message:    err.Error(),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	return s.repo.SetMetricBulk(&metrics)
 }
 
 func isMetricNameAlphanumeric(input string, r *regexp.Regexp) bool {
 	return r.MatchString(input)
 }
 
-func withRetry(fn func() error, attempts int, maxAttempts int) error {
-	if maxAttempts == 0 {
-		return fn()
+func isMetricDataOK(m *models.Metrics) bool {
+	switch m.MType {
+	case models.Gauge:
+		return m.Value != nil
+	case models.Counter:
+		return m.Delta != nil
+	default:
+		return false
 	}
-	if attempts >= maxAttempts {
-		return fmt.Errorf("max retry attempts reached")
+}
+
+func isHashValid(signature, payload, secret []byte) bool {
+	if len(signature) == 0 || len(payload) == 0 || len(secret) == 0 {
+		return false
 	}
-	secondsToSleep := time.Duration(2*(attempts)+1) * time.Second
-	var retriableErr *repository.RetriablePgError
-	if err := fn(); err != nil {
-		if errors.As(err, &retriableErr) {
-			time.Sleep(secondsToSleep)
-			return withRetry(fn, attempts+1, maxAttempts)
-		}
-		return err
+	decodedSignature := make([]byte, sha256.Size)
+	_, err := hex.Decode(decodedSignature, signature)
+	if err != nil {
+		return false
 	}
-	return nil
+	h := hmac.New(sha256.New, secret)
+	h.Write(payload)
+	hash := h.Sum(nil)
+	return hmac.Equal(decodedSignature, hash)
 }

--- a/internal/service/metric_test.go
+++ b/internal/service/metric_test.go
@@ -68,14 +68,15 @@ func TestNewMetricService(t *testing.T) {
 				repo: &metricRepoStub{},
 			},
 			want: &metricService{
-				re:   regexp.MustCompile(`^\w+$`),
-				repo: &metricRepoStub{},
+				re:         regexp.MustCompile(`^\w+$`),
+				repo:       &metricRepoStub{},
+				hashSecret: []byte(""),
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := NewMetricService(tt.args.repo)
+			actual := NewMetricService(tt.args.repo, []byte(""))
 			require.True(t, reflect.DeepEqual(actual, tt.want))
 		})
 	}

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"errors"
+	"time"
+)
+
+type RetriableError interface {
+	error
+	IsRetriable() bool
+}
+
+func WithRetry(fn func() error, attempts int, maxAttempts int) error {
+	if maxAttempts == 0 {
+		return fn()
+	}
+	if attempts >= maxAttempts {
+		return errors.New("max attempts reached")
+	}
+	secondsToSleep := time.Duration(2*(attempts)+1) * time.Second
+	var retriableErr RetriableError
+	if err := fn(); err != nil {
+		if errors.As(err, &retriableErr) && retriableErr.IsRetriable() {
+			time.Sleep(secondsToSleep)
+			return WithRetry(fn, attempts+1, maxAttempts)
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Привет!
Постарался насколько меня хватило исправить открытые замечания к iter13: 
https://github.com/funkymotions/go-ya-practicum-metrics/pull/13
Правда, почему-то у меня как-то странно отобразились комментарии к коду (без привязки к лайнам), но постарался определить по контексту комментариев, более менее понятно.

Лишь уточню, про defer и мьютекс: насколько понял, в теории, правило может быть формализовано так:
высвобождение ресурса только в случае его успешного использования? (сначала прочитали/заблокировали/аллоцировали, следующим действием - высвобождение). 
Потенциально плохая история, т. к. если ресурс не захвачен - место для паники?:
```
defer mu.Unlock()
...
mu.Lock()
```
Более идеоматичный подход:
```
mu.Lock()
...
defer mu.Unlock()
```
